### PR TITLE
Add pagination to board list

### DIFF
--- a/boards/tests/test_apis.py
+++ b/boards/tests/test_apis.py
@@ -122,8 +122,8 @@ def test_get_board_list(api_client_with_credentials: APIClientWithUser) -> None:
     response = api_client_with_credentials.get(boards_url())
 
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 2
-    assert response.json() == [{"name": board_1.name}, {"name": board_2.name}]
+    assert len(response.json()["results"]) == 2
+    assert response.json()["results"] == [{"name": board_1.name}, {"name": board_2.name}]
 
 
 @pytest.mark.django_db
@@ -133,8 +133,8 @@ def test_get_board_list_filter_by_name(api_client_with_credentials: APIClientWit
     response = api_client_with_credentials.get(boards_url(query_kwargs={"name": board_1.name}))
 
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json() == [{"name": board_1.name}]
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"] == [{"name": board_1.name}]
 
 
 @pytest.mark.django_db
@@ -146,8 +146,8 @@ def test_get_board_list_filter_by_name_multiple_results(api_client_with_credenti
     response = api_client_with_credentials.get(boards_url(query_kwargs={"name": "test"}))
 
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 2
-    assert response.json() == [{"name": board_1.name}, {"name": board_2.name}]
+    assert len(response.json()["results"]) == 2
+    assert response.json()["results"] == [{"name": board_1.name}, {"name": board_2.name}]
 
 
 @pytest.mark.django_db
@@ -160,8 +160,8 @@ def test_get_board_list_filter_is_member(api_client_with_credentials: APIClientW
     response = api_client_with_credentials.get(boards_url(query_kwargs={"is_member": True}))
 
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json() == [{"name": board_1.name}]
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"] == [{"name": board_1.name}]
 
 
 @pytest.mark.django_db
@@ -176,8 +176,8 @@ def test_get_board_list_filter_is_admin(api_client_with_credentials: APIClientWi
     response = api_client_with_credentials.get(boards_url(query_kwargs={"is_admin": True}))
 
     assert response.status_code == status.HTTP_200_OK
-    assert len(response.json()) == 1
-    assert response.json() == [{"name": board_1.name}]
+    assert len(response.json()["results"]) == 1
+    assert response.json()["results"] == [{"name": board_1.name}]
 
 
 @pytest.mark.django_db

--- a/common/pagination.py
+++ b/common/pagination.py
@@ -1,0 +1,67 @@
+from collections import OrderedDict
+from typing import Any, List, Type
+
+from django.db.models import QuerySet
+from rest_framework.pagination import BasePagination
+from rest_framework.pagination import LimitOffsetPagination as _LimitOffsetPagination
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.serializers import Serializer
+from rest_framework.views import APIView
+
+
+def get_paginated_response(
+    *,
+    pagination_class: Type[BasePagination],
+    serializer_class: Type[Serializer[Any]],
+    queryset: QuerySet[Any],
+    request: Request,
+    view: APIView
+) -> Response:
+    """
+    Return a paginated response.
+
+    This code is taken from Django-Styleguide: https://github.com/HackSoftware/Django-Styleguide#filters--pagination
+    """
+    paginator = pagination_class()
+
+    page = paginator.paginate_queryset(queryset, request, view=view)
+
+    if page is not None:
+        serializer = serializer_class(page, many=True)
+        return paginator.get_paginated_response(serializer.data)
+
+    serializer = serializer_class(queryset, many=True)
+
+    return Response(data=serializer.data)
+
+
+class LimitOffsetPagination(_LimitOffsetPagination):
+    """
+    Base class for Pagination classes used in APIs.
+
+    This code is taken from Django-Styleguide: https://github.com/HackSoftware/Django-Styleguide#filters--pagination
+    """
+
+    default_limit = 10
+    max_limit = 50
+
+    def get_paginated_response(self, data: List[Any]) -> Response:
+        """
+        Return paginated response.
+
+        We redefine this method in order to return `limit` and `offset`.
+        This is used by the frontend to construct the pagination itself.
+        """
+        return Response(
+            OrderedDict(
+                [
+                    ("limit", self.limit),
+                    ("offset", self.offset),
+                    ("count", self.count),
+                    ("next", self.get_next_link()),
+                    ("previous", self.get_previous_link()),
+                    ("results", data),
+                ]
+            )
+        )


### PR DESCRIPTION
## Description
Add pagination mechanism from Django-Styleguide and implement it for the board list.
Close #24 

## Related Issue
[Add pagination to board list](https://github.com/dflss/boards-of-django/issues/24)

