### PR TITLE
Order posts by id instead of created_at

### DIFF
--- a/boards/selectors.py
+++ b/boards/selectors.py
@@ -84,7 +84,7 @@ def post_list(
         else:
             qs = qs.filter(~Q(creator=user))
 
-    return qs.order_by("-created_at")
+    return qs.order_by("-id")
 
 
 def post_get(*, post_id: int) -> Optional[Post]:


### PR DESCRIPTION
## Description
The result will be the same as ids are incremented with each created object. However, less queries will be used.

