### PR TITLE
Allow null in FilterSerializer for Boards

### DIFF
--- a/boards/apis.py
+++ b/boards/apis.py
@@ -72,11 +72,7 @@ class BoardsApi(APIView):
         filters_serializer = self.FilterSerializer(data=request.query_params)
         filters_serializer.is_valid(raise_exception=True)
 
-        print(request.query_params)
-
         boards = board_list(**filters_serializer.validated_data, user=request.user)
-
-        print(boards)
 
         return get_paginated_response(
             pagination_class=self.Pagination,

--- a/boards/apis.py
+++ b/boards/apis.py
@@ -60,8 +60,8 @@ class BoardsApi(APIView):
 
     class FilterSerializer(serializers.Serializer[Any]):
         name = serializers.CharField(required=False)
-        is_member = serializers.BooleanField(required=False)
-        is_admin = serializers.BooleanField(required=False)
+        is_member = serializers.BooleanField(required=False, allow_null=True, default=None)
+        is_admin = serializers.BooleanField(required=False, allow_null=True, default=None)
 
     class OutputSerializer(serializers.Serializer[Any]):
         name = serializers.CharField()
@@ -72,7 +72,11 @@ class BoardsApi(APIView):
         filters_serializer = self.FilterSerializer(data=request.query_params)
         filters_serializer.is_valid(raise_exception=True)
 
+        print(request.query_params)
+
         boards = board_list(**filters_serializer.validated_data, user=request.user)
+
+        print(boards)
 
         return get_paginated_response(
             pagination_class=self.Pagination,

--- a/boards/tests/test_apis.py
+++ b/boards/tests/test_apis.py
@@ -134,6 +134,7 @@ def test_create_board_name_not_unique(
 def test_get_board_list(api_client_with_credentials: APIClientWithUser) -> None:
     board_1 = BoardFactory()
     board_2 = BoardFactory()
+    board_1.members.add(api_client_with_credentials.user)
 
     response = api_client_with_credentials.get(boards_url())
 


### PR DESCRIPTION
## Description
Fix the fact that only the boards that a user is a member of show up when querying `/boards` endpoint.

Close #43 