### PR TITLE
Bump isort version in pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
         args: ["--filter-files"]


### PR DESCRIPTION
## Description
Pre-commit was failing due to bug in isort: https://github.com/PyCQA/isort/issues/2077

