### PR TITLE
Downgrade pyyaml version to 5.3.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -77,7 +77,7 @@ pytest-django==4.5.2
 pytest-factoryboy==2.5.0
 python-dateutil==2.8.2
 pytz==2022.4
-PyYAML==6.0
+PyYAML==5.3.1
 redis==4.3.4
 requests==2.28.1
 ruamel.yaml==0.17.21


### PR DESCRIPTION
## Description
Temporarily downgrade Pyyaml version until a better solution is found. More context here: https://github.com/yaml/pyyaml/issues/724

